### PR TITLE
chore(logout): narrow MockLogoutConfig to MetadataURL() only

### DIFF
--- a/internal/auth/logout/handler_test.go
+++ b/internal/auth/logout/handler_test.go
@@ -12,11 +12,7 @@ import (
 
 type MockLogoutConfig struct{}
 
-func (m *MockLogoutConfig) MetadataURL() string           { return "https://mock.metadata.url" }
-func (m *MockLogoutConfig) ClientSecretValue() string     { return "secret" }
-func (m *MockLogoutConfig) RedirectURIValue() string      { return "https://example.com/callback" }
-func (m *MockLogoutConfig) ScopeValue() string            { return "openid" }
-func (m *MockLogoutConfig) UserPoolClientIDValue() string { return "client-id" }
+func (m *MockLogoutConfig) MetadataURL() string { return "https://mock.metadata.url" }
 
 func TestLogoutHandlerRedirectsToLogoutEndpoint(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
chore(logout): narrow MockLogoutConfig to MetadataURL() only