### PR TITLE
chore(root): clarify that the root endpoint is for browser access

### DIFF
--- a/internal/root/handler.go
+++ b/internal/root/handler.go
@@ -5,7 +5,9 @@ import (
 )
 
 // @Summary Redirect to login
-// @Description Redirects the root path (/) to the login page
+// @Description Redirects the root path (/) to the login page.
+// @Description This endpoint is intended to be accessed via a web browser.
+// @Description It performs an HTTP redirect (status code 302) to /login.
 // @Tags system
 // @Produce plain
 // @Success 302 {string} string "Found"


### PR DESCRIPTION
chore(root): clarify that the root endpoint is for browser access