### PR TITLE
Fix/lambda startup

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Build Docker image
         run: |
-          docker build -t cognito-repeater-go:prod -f Dockerfile.prod .
+          docker build --no-cache -t cognito-repeater-go:prod -f Dockerfile.prod .
 
       - name: Tag image with commit SHA
         run: |


### PR DESCRIPTION
chore(cd): temporarily disable paths-filter to ensure all changes trigger deployment
fix(cd): force docker rebuild with --no-cache to ensure digest changes trigger Lambda redeploy