### PR TITLE
refactor(health): rename /ping to /health; unify handler, response, and test names

### DIFF
--- a/internal/health/handler.go
+++ b/internal/health/handler.go
@@ -1,4 +1,4 @@
-package ping
+package health
 
 import (
 	"encoding/json"
@@ -11,18 +11,18 @@ import (
 // @Description Returns "pong" to indicate the server is alive
 // @Tags health
 // @Produce json
-// @Success 200 {object} ping.PingResponse "pong message"
-// @Router /ping [get]
-func NewPingHandler(logger *zap.Logger) http.HandlerFunc {
+// @Success 200 {object} health.HealthgResponse "pong message"
+// @Router /health [get]
+func NewHealthHandler(logger *zap.Logger) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		logger.Info("responding to /ping")
+		logger.Info("responding to /health")
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		resp := PingResponse{Message: "pong"}
+		resp := HealthResponse{Message: "pong"}
 		if err := json.NewEncoder(w).Encode(resp); err != nil {
-			logger.Error("failed to write ping response", zap.Error(err))
+			logger.Error("failed to write health response", zap.Error(err))
 		}
 	}
 }

--- a/internal/health/handler_test.go
+++ b/internal/health/handler_test.go
@@ -1,4 +1,4 @@
-package ping
+package health
 
 import (
 	"encoding/json"
@@ -7,20 +7,18 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"cognito-repeater-go/test/testhelpers"
 
-	"go.uber.org/zap"
+	"github.com/stretchr/testify/assert"
 )
 
-func TestNewPingHandler_ReturnsPong(t *testing.T) {
+func TestNewHealthHandler_ReturnsPong(t *testing.T) {
 	t.Parallel()
 
-	req := httptest.NewRequest(http.MethodGet, "/ping", nil)
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
 	w := httptest.NewRecorder()
 
-	mockLogger := zap.NewNop()
-
-	NewPingHandler(mockLogger)(w, req)
+	NewHealthHandler(testhelpers.MockLogger)(w, req)
 
 	resp := w.Result()
 	body, err := io.ReadAll(resp.Body)
@@ -28,7 +26,7 @@ func TestNewPingHandler_ReturnsPong(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-	var res PingResponse
+	var res HealthResponse
 	err = json.Unmarshal(body, &res)
 	assert.NoError(t, err)
 	assert.Equal(t, "pong", res.Message)

--- a/internal/health/ping/response.go
+++ b/internal/health/ping/response.go
@@ -1,7 +1,0 @@
-package ping
-
-// PingResponse represents a simple health check response.
-// Typically used for /ping endpoint.
-type PingResponse struct {
-	Message string `json:"message" example:"pong"`
-}

--- a/internal/health/response.go
+++ b/internal/health/response.go
@@ -1,0 +1,7 @@
+package health
+
+// HealthResponse represents a simple health check response.
+// Typically used for /health endpoint.
+type HealthResponse struct {
+	Message string `json:"message" example:"pong"`
+}

--- a/internal/health/routes.go
+++ b/internal/health/routes.go
@@ -3,11 +3,9 @@ package health
 import (
 	"net/http"
 
-	"cognito-repeater-go/internal/health/ping"
-
 	"go.uber.org/zap"
 )
 
 func RegisterHealthRoutes(mux *http.ServeMux, logger *zap.Logger) {
-	mux.HandleFunc("/ping", ping.NewPingHandler(logger))
+	mux.HandleFunc("/health", NewHealthHandler(logger))
 }

--- a/test/health/health_route_test.go
+++ b/test/health/health_route_test.go
@@ -7,25 +7,23 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"cognito-repeater-go/internal/health/ping"
+	"cognito-repeater-go/internal/health"
 	"cognito-repeater-go/internal/router"
 	"cognito-repeater-go/test/testhelpers"
 
 	"github.com/stretchr/testify/assert"
-
-	"go.uber.org/zap"
 )
 
 func TestPingRouteReturnsPlainTextPong(t *testing.T) {
 	t.Parallel()
 
-	deps := testhelpers.NewMockRouteDependencies()
-	cli := testhelpers.NewMockHTTPClientOK()
-	mockLogger := zap.NewNop()
+	r := router.NewRouter(
+		testhelpers.NewMockRouteDependencies(),
+		testhelpers.NewMockHTTPClientOK(),
+		testhelpers.MockLogger,
+	)
 
-	r := router.NewRouter(deps, cli, mockLogger)
-
-	req := httptest.NewRequest(http.MethodGet, "/ping", nil)
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
 	w := httptest.NewRecorder()
 
 	r.ServeHTTP(w, req)
@@ -35,7 +33,7 @@ func TestPingRouteReturnsPlainTextPong(t *testing.T) {
 	assert.NoError(t, err, "failed to read response body")
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-	var res ping.PingResponse
+	var res health.HealthResponse
 	err = json.Unmarshal(body, &res)
 	assert.NoError(t, err)
 	assert.Equal(t, "pong", res.Message)


### PR DESCRIPTION
refactor(health): rename /ping to /health; unify handler, response, and test names