### PR TITLE
docs(openapi): remove authorization parameters from /me and /whoami endpoints

### DIFF
--- a/internal/openapi/openapi.yaml
+++ b/internal/openapi/openapi.yaml
@@ -322,14 +322,6 @@ paths:
         CORS enabled: This endpoint includes `Access-Control-Allow-Origin: *` in its response headers.
       tags:
         - user
-      parameters:
-        - name: Authorization
-          in: header
-          required: true
-          description: Bearer ID token
-          schema:
-            type: string
-            example: Bearer <ID_TOKEN>
       security:
         - BearerAuth: []
       responses:
@@ -504,14 +496,6 @@ paths:
         CORS enabled: This endpoint includes `Access-Control-Allow-Origin: *` in its response headers.
       tags:
         - user
-      parameters:
-        - name: Authorization
-          in: header
-          required: true
-          description: Bearer Access token
-          schema:
-            type: string
-            example: Bearer <ACCESS_TOKEN>
       security:
         - BearerAuth: []
       responses:


### PR DESCRIPTION
docs(openapi): remove authorization parameters from /me and /whoami endpoints