### PR TITLE
Chore/openapi

### DIFF
--- a/internal/openapi/openapi.yaml
+++ b/internal/openapi/openapi.yaml
@@ -223,11 +223,7 @@ paths:
                 token:
                   type: string
                   description: Refresh token to be revoked
-            examples:
-              sample:
-                summary: Example refresh token payload
-                value:
-                  token: refresh_token
+                  example: refresh_token
       responses:
         "204":
           description: No Content


### PR DESCRIPTION
chore(openapi): remove query parameter to prevent misuse via Swagger UI in /logout
chore(openapi): move example for token field into schema for proper Swagger UI display