### PR TITLE
chore(openapi): switch token field example from refresh_token to <REFRESH_TOKEN> in /revoke

### DIFF
--- a/internal/openapi/openapi.yaml
+++ b/internal/openapi/openapi.yaml
@@ -223,7 +223,7 @@ paths:
                 token:
                   type: string
                   description: Refresh token to be revoked
-                  example: refresh_token
+                  example: <REFRESH_TOKEN>
       responses:
         "204":
           description: No Content


### PR DESCRIPTION
chore(openapi): switch token field example from refresh_token to <REFRESH_TOKEN> in /revoke